### PR TITLE
Create python requirements file

### DIFF
--- a/ColorGAN 2/requirements.txt
+++ b/ColorGAN 2/requirements.txt
@@ -1,0 +1,9 @@
+python_version >= 3.6
+Keras
+numpy
+glob2
+pillow
+scipy
+Flask
+tensorflow
+tensorflow_addons


### PR DESCRIPTION
This PR creates a python requirements file which can be installed with ``pip install -r requirements.txt``.